### PR TITLE
Accessibility: Use Labels instead of placeholders.

### DIFF
--- a/MobWxUI/MobWxUI.csproj
+++ b/MobWxUI/MobWxUI.csproj
@@ -27,7 +27,7 @@
 		<ApplicationId>com.companyname.mobwxui</ApplicationId>
 
 		<!-- Versions -->
-		<ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
+		<ApplicationDisplayVersion>1.1</ApplicationDisplayVersion>
 		<ApplicationVersion>1</ApplicationVersion>
 
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">11.0</SupportedOSPlatformVersion>
@@ -65,10 +65,10 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="CommunityToolkit.Maui" Version="7.0.0" />
+		<PackageReference Include="CommunityToolkit.Maui" Version="9.0.0" />
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
-		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
-		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
+		<PackageReference Include="Microsoft.Maui.Controls" Version="8.0.40" />
+		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.40" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
 	</ItemGroup>
 

--- a/MobWxUI/Views/MainPage.xaml
+++ b/MobWxUI/Views/MainPage.xaml
@@ -36,8 +36,7 @@
             <VerticalStackLayout>
                 <Label Text="Get a forecast for: City, State"
                        Style="{StaticResource InputLabel}" />
-                <Editor Placeholder="city name, ST"
-                        Text="{Binding CityState}" 
+                <Editor Text="{Binding CityState}" 
                         HorizontalTextAlignment="Center" />
                 <Button Text="Set Location (future)"
                         Command="{Binding ClickCityState}"
@@ -45,10 +44,9 @@
             </VerticalStackLayout>
 
             <VerticalStackLayout>
-                <Label Text="Enter a location in decimal degrees"
+                <Label Text="Enter Coordinates (Seattle is 47.6036,-122.3306)"
                        Style="{StaticResource InputLabel}" />
-                <Editor Placeholder="Example: 34.567,-121.234"
-                        Text="{Binding LatLonEntry}"
+                <Editor Text="{Binding LatLonEntry}"
                         HorizontalTextAlignment="Center"
                         ToolTipProperties.Text="Enter coordinates in Decimal Degrees."
                         />


### PR DESCRIPTION
- [x] Usability and A11y: Remove placeholders in display and input elements.
- [x] Use Labels to perform the duty of the removed placeholders.
